### PR TITLE
Fix error on adding multiple files

### DIFF
--- a/functions/__git_add.fish
+++ b/functions/__git_add.fish
@@ -1,10 +1,7 @@
 function __git_add
   commandline | read -l buffer
-  git status --porcelain | \
-        angler "$ANGLER_QUERY_OPTION '$buffer'" | \
-        awk -v git_root=:/ '{print git_root$2}' | \
-        tr '\n' ' ' | \
-        read -l selected_files
+  set selected_files (git status --porcelain | angler "$ANGLER_QUERY_OPTION '$buffer'" | \
+    cut -d ' ' -f 2- | sed -e 's/^/:\//' | string escape -n)
   if test -n "$selected_files"
     commandline "git add $selected_files"
     commandline -f execute


### PR DESCRIPTION
If the selected file name contains a space character, `__git_add` function fails.
This PR fix this issue.

```sh
$ ls
foo bar.txt

# then execute git-add-keybind and select "foo bar.txt"

$ git add :/foo
fatal: pathspec ':/foo' did not match any files
```