### PR TITLE
Unescape selected filename

### DIFF
--- a/functions/__git_add.fish
+++ b/functions/__git_add.fish
@@ -1,7 +1,7 @@
 function __git_add
     commandline | read -l buffer
     set selected_files (git status --porcelain | angler "$ANGLER_QUERY_OPTION '$buffer'" | \
-      string sub -s 4 | sed -e 's/^/:\//' | string escape -n)
+      string sub -s 4 | sed -e 's/^/:\//' | string unescape | string escape -n)
     if test -n "$selected_files"
         commandline "git add $selected_files"
         commandline -f execute


### PR DESCRIPTION
If the file name contains space and has been changed, the result of `git status --porcelain` will be surrounded by double quotations.
To pass it as a `git add` argument, we need to unescaped it once, then escape it again without quoting.